### PR TITLE
Add appium script run on simulator

### DIFF
--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+  # pull_request:
+  #   branches:
+  #     - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install Appium and Python Dependencies
         run: |
           npm install -g appium
-          python3 -m pip install Appium-Python-Client
+          python3 -m pip install --break-system-packages Appium-Python-Client
 
       - name: Start Appium Server
         run: |

--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Run Appium UI Test
         env:
           # Pass the built app's path to the test script; Appium requires the .app folder.
-          APP_PATH: "$GITHUB_WORKSPACE/build/MASTestApp.xcarchive/Products/Applications/MASTestApp.app"
+          APP_PATH: "build/MASTestApp.xcarchive/Products/Applications/MASTestApp.app"
         run: |
           python3 tools/appium_script.py
 

--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -60,10 +60,8 @@ jobs:
           name: Unsigned-iOS-App
           path: output/MASTestApp-unsigned.ipa
 
-
-      - name: Check Available Devices
-        run: |
-          xcrun simctl list devices available
+      - name: List Applications Directory
+        run: ls -la build/MASTestApp.xcarchive/Products/Applications/
 
       - name: Install Appium and Python Dependencies
         run: |

--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -113,3 +113,13 @@ jobs:
             before_start.png
             after_start.png
             final_screen.xml
+
+      - name: Generate Job Summary
+        run: |
+          BEFORE=$(base64 before_start.png | tr -d '\n')
+          AFTER=$(base64 after_start.png | tr -d '\n')
+          echo "## Job Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Test Artifacts:**" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "<table><tr><td><img src='data:image/png;base64,$BEFORE' width='300'></td><td><img src='data:image/png;base64,$AFTER' width='300'></td></tr></table>" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -61,7 +61,7 @@ jobs:
           path: output/MASTestApp-unsigned.ipa
 
       - name: List Applications Directory
-        run: ls -la "$GITHUB_WORKSPACE/build/MASTestApp.xcarchive/Products/Applications/
+        run: ls -la "$GITHUB_WORKSPACE/build/MASTestApp.xcarchive/Products/Applications/"
 
       - name: Install Appium and Python Dependencies
         run: |

--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -76,7 +76,7 @@ jobs:
           # Pass the built app's path to the test script; Appium requires the .app folder.
           APP_PATH: "$GITHUB_WORKSPACE/build/MASTestApp.xcarchive/Products/Applications/MASTestApp.app"
         run: |
-          python3 appium_script.py
+          python3 tools/appium_script.py
 
       - name: Upload Test Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -62,7 +62,18 @@ jobs:
 
       - name: Boot Simulator
         run: |
-          xcrun simctl boot "iPhone 15" || echo "Simulator already booted"
+          set -e
+          xcrun simctl shutdown all
+          xcrun simctl erase all
+          if ! xcrun simctl boot "iPhone 15"; then
+            echo "Failed to boot simulator 'iPhone 15'. Exiting."
+            exit 1
+          fi
+          if ! xcrun simctl bootstatus "iPhone 15" -b; then
+            echo "Simulator 'iPhone 15' did not finish booting in time. Exiting."
+            exit 1
+          fi
+
 
       - name: Install Appium and Python Dependencies
         run: |

--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -1,0 +1,85 @@
+name: Build iOS App and Run Appium Test
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          brew install ldid
+          brew install cocoapods
+          pod install --repo-update || true
+
+      - name: Set Default Scheme
+        run: |
+          scheme_list=$(xcodebuild -list -json | tr -d "\n")
+          default=$(echo $scheme_list | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
+          echo "DEFAULT_SCHEME=$default" >> $GITHUB_ENV
+          echo "Using default scheme: $default"
+
+      - name: Build the app (unsigned)
+        run: |
+          xcodebuild archive \
+            -project "MASTestApp.xcodeproj" \
+            -scheme "$DEFAULT_SCHEME" \
+            -archivePath "$GITHUB_WORKSPACE/build/MASTestApp.xcarchive" \
+            -configuration Release \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Add Entitlements
+        run: |
+          ldid -Sentitlements.plist "$GITHUB_WORKSPACE/build/MASTestApp.xcarchive/Products/Applications/MASTestApp.app/MASTestApp"
+
+      - name: Create IPA manually
+        run: |
+          cd "$GITHUB_WORKSPACE/build/MASTestApp.xcarchive/Products" || exit
+          mv Applications Payload
+          zip -r9q MASTestApp.zip Payload
+          mv MASTestApp.zip MASTestApp.ipa
+          mkdir -p "$GITHUB_WORKSPACE/output"
+          mv MASTestApp.ipa "$GITHUB_WORKSPACE/output/MASTestApp-unsigned.ipa"
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Unsigned-iOS-App
+          path: output/MASTestApp-unsigned.ipa
+
+      - name: Install Appium and Python Dependencies
+        run: |
+          npm install -g appium
+          python3 -m pip install Appium-Python-Client
+
+      - name: Start Appium Server
+        run: |
+          # Start Appium in the background and give it a few seconds to initialize
+          appium & 
+          sleep 10
+
+      - name: Run Appium UI Test
+        env:
+          # Pass the built app's path to the test script; Appium requires the .app folder.
+          APP_PATH: "$GITHUB_WORKSPACE/build/MASTestApp.xcarchive/Products/Applications/MASTestApp.app"
+        run: |
+          python3 appium_script.py
+
+      - name: Upload Test Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: UI-Test-Artifacts
+          path: |
+            before_start.png
+            after_start.png
+            final_screen.xml

--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -60,8 +60,9 @@ jobs:
           name: Unsigned-iOS-App
           path: output/MASTestApp-unsigned.ipa
 
-      - name: List Applications Directory
-        run: ls -la "$GITHUB_WORKSPACE/build/MASTestApp.xcarchive/Products/Payload"
+      - name: Boot Simulator
+        run: |
+          xcrun simctl boot "iPhone 15" || echo "Simulator already booted"
 
       - name: Install Appium and Python Dependencies
         run: |

--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -60,21 +60,6 @@ jobs:
           name: Unsigned-iOS-App
           path: output/MASTestApp-unsigned.ipa
 
-      - name: Boot Simulator
-        run: |
-          set -e
-          xcrun simctl shutdown all
-          xcrun simctl erase all
-          if ! xcrun simctl boot "iPhone 15"; then
-            echo "Failed to boot simulator 'iPhone 15'. Exiting."
-            exit 1
-          fi
-          if ! xcrun simctl bootstatus "iPhone 15" -b; then
-            echo "Simulator 'iPhone 15' did not finish booting in time. Exiting."
-            exit 1
-          fi
-
-
       - name: Install Appium and Python Dependencies
         run: |
           npm install -g appium
@@ -89,6 +74,31 @@ jobs:
           # Start Appium in the background and give it a few seconds to initialize
           appium & 
           sleep 10
+
+      - name: Set Xcode version
+        run: |
+          sudo xcode-select --switch /Applications/Xcode.app
+          xcodebuild -version
+
+      - name: Warm up iOS SDK version command
+        run: |
+          echo "Warming up xcrun..."
+          # This should output the SDK version (e.g. 17.4); if it hangs here, the issue is with Xcode/CLI tools.
+          xcrun --sdk iphonesimulator --show-sdk-version
+
+      - name: Boot Simulator
+        run: |
+          set -e
+          xcrun simctl shutdown all
+          xcrun simctl erase all
+          if ! xcrun simctl boot "iPhone 15"; then
+            echo "Failed to boot simulator 'iPhone 15'. Exiting."
+            exit 1
+          fi
+          if ! xcrun simctl bootstatus "iPhone 15" -b; then
+            echo "Simulator 'iPhone 15' did not finish booting in time. Exiting."
+            exit 1
+          fi
 
       - name: Run Appium UI Test
         env:

--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -1,64 +1,23 @@
-name: Build iOS App and Run Appium Test
+name: Appium Test
 
 on:
   push:
-    branches:
-      - main
-  # pull_request:
-  #   branches:
-  #     - main
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: macos-latest
+    env:
+      BUNDLE_IDENTIFIER: org.owasp.mastestapp.MASTestApp-iOS
+      PLATFORM: "iOS Simulator"
+      SIMULATOR: "iPhone 16"
 
     steps:
-      - name: Checkout code
+      - name: Checkout Code
         uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: |
-          brew install ldid
-          brew install cocoapods
-          pod install --repo-update || true
-
-      - name: Set Default Scheme
-        run: |
-          scheme_list=$(xcodebuild -list -json | tr -d "\n")
-          default=$(echo $scheme_list | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
-          echo "DEFAULT_SCHEME=$default" >> $GITHUB_ENV
-          echo "Using default scheme: $default"
-
-      - name: Build the app (unsigned)
-        run: |
-          xcodebuild archive \
-            -project "MASTestApp.xcodeproj" \
-            -scheme "$DEFAULT_SCHEME" \
-            -archivePath "$GITHUB_WORKSPACE/build/MASTestApp.xcarchive" \
-            -configuration Release \
-            CODE_SIGN_IDENTITY="" \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO
-
-      - name: Add Entitlements
-        run: |
-          ldid -Sentitlements.plist "$GITHUB_WORKSPACE/build/MASTestApp.xcarchive/Products/Applications/MASTestApp.app/MASTestApp"
-
-      - name: Create IPA manually
-        run: |
-          cd "$GITHUB_WORKSPACE/build/MASTestApp.xcarchive/Products" || exit
-          mv Applications Payload
-          zip -r9q MASTestApp.zip Payload
-          mv MASTestApp.zip MASTestApp.ipa
-          mkdir -p "$GITHUB_WORKSPACE/output"
-          mv MASTestApp.ipa "$GITHUB_WORKSPACE/output/MASTestApp-unsigned.ipa"
-
-      - name: Upload Build Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: Unsigned-iOS-App
-          path: output/MASTestApp-unsigned.ipa
 
       - name: Install Appium and Python Dependencies
         run: |
@@ -73,37 +32,76 @@ jobs:
         run: |
           # Start Appium in the background and give it a few seconds to initialize
           appium & 
-          sleep 10
+          # sleep 10
 
-      - name: Set Xcode version
+      - name: Install Dependencies
         run: |
-          sudo xcode-select --switch /Applications/Xcode.app
-          xcodebuild -version
+          brew install ldid || true
+          brew install cocoapods || true
+          if [ -f Podfile ]; then
+            pod install --repo-update || true
+          fi
 
-      - name: Warm up iOS SDK version command
+      - name: Set Default Scheme
         run: |
-          echo "Warming up xcrun..."
-          # This should output the SDK version (e.g. 17.4); if it hangs here, the issue is with Xcode/CLI tools.
-          xcrun --sdk iphonesimulator --show-sdk-version
+          scheme_list=$(xcodebuild -list -json | tr -d "\n")
+          default=$(echo "$scheme_list" | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
+          echo "DEFAULT_SCHEME=$default" >> $GITHUB_ENV
+          echo "Using default scheme: $default"
+
+      - name: Build App for Simulator
+        run: |
+          if ls -A | grep -iq "\.xcworkspace$"; then
+            filetype_parameter="workspace"
+            file_to_build=$(ls -A | grep -i "\.xcworkspace$")
+          else
+            filetype_parameter="project"
+            file_to_build=$(ls -A | grep -i "\.xcodeproj$")
+          fi
+          file_to_build=$(echo "$file_to_build" | awk '{$1=$1;print}')
+          # Build for simulator with code signing disabled
+          xcodebuild build \
+            -scheme "$DEFAULT_SCHEME" \
+            -"$filetype_parameter" "$file_to_build" \
+            -destination "platform=$PLATFORM,name=$SIMULATOR" \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
 
       - name: Boot Simulator
         run: |
-          set -e
-          xcrun simctl shutdown all
-          xcrun simctl erase all
-          if ! xcrun simctl boot "iPhone 15"; then
-            echo "Failed to boot simulator 'iPhone 15'. Exiting."
+          # Boot the selected simulator if not already booted
+          xcrun simctl boot "$SIMULATOR" || echo "Simulator already booted"
+          # Allow time for the simulator to finish booting
+          sleep 10
+
+      - name: Install and Launch App on Simulator
+        run: |
+          # Locate the built .app from DerivedData
+          APP_PATH=$(find ~/Library/Developer/Xcode/DerivedData -name "*.app" | head -n 1)
+          if [ -z "$APP_PATH" ]; then
+            echo "Error: Could not find the built .app file."
             exit 1
           fi
-          if ! xcrun simctl bootstatus "iPhone 15" -b; then
-            echo "Simulator 'iPhone 15' did not finish booting in time. Exiting."
-            exit 1
-          fi
+          echo "Installing app from: $APP_PATH"
+          xcrun simctl install "$SIMULATOR" "$APP_PATH"
+          echo "Launching app with bundle identifier $BUNDLE_IDENTIFIER"
+          xcrun simctl launch "$SIMULATOR" "$BUNDLE_IDENTIFIER"
+
+      - name: Capture Screenshot
+        run: |
+          # Wait for the app to fully launch before taking a screenshot
+          sleep 10
+          xcrun simctl io "$SIMULATOR" screenshot screenshot.png
+
+      - name: Upload Screenshot Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: iOS-Screenshot
+          path: screenshot.png
 
       - name: Run Appium UI Test
-        env:
+        # env: # currently not working so we attach to the running app instead
           # Pass the built app's path to the test script; Appium requires the .app folder.
-          APP_PATH: "build/MASTestApp.xcarchive/Products/Payload/MASTestApp.app"
+          # APP_PATH: "build/MASTestApp.xcarchive/Products/Applications/MASTestApp.app"
         run: |
           python3 tools/appium_script.py
 

--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -113,30 +113,3 @@ jobs:
             before_start.png
             after_start.png
             final_screen.xml
-
-  summarize:
-    runs-on: ubuntu-latest
-    needs: build  # Wait until the build job completes
-    steps:
-      - name: Download UI Test Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: UI-Test-Artifacts
-          path: ./artifacts
-
-      - name: Create Job Summary
-        run: |
-
-          echo "## Job Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Test Artifacts" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Display the two images side by side in a table
-          echo "<table><tr>" >> $GITHUB_STEP_SUMMARY
-          echo "<td><img src='./artifacts/before_start.png' width='300'></td>" >> $GITHUB_STEP_SUMMARY
-          echo "<td><img src='./artifacts/after_start.png' width='300'></td>" >> $GITHUB_STEP_SUMMARY
-          echo "</tr></table>" >> $GITHUB_STEP_SUMMARY
-
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**XML Dump:** final_screen.xml (download from artifacts)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -64,6 +64,10 @@ jobs:
         run: |
           npm install -g appium
           python3 -m pip install --break-system-packages Appium-Python-Client
+      
+      - name: Install Appium Driver for XCUITest
+        run: |
+          appium driver install xcuitest
 
       - name: Start Appium Server
         run: |

--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -61,7 +61,7 @@ jobs:
           path: output/MASTestApp-unsigned.ipa
 
       - name: List Applications Directory
-        run: ls -la build/MASTestApp.xcarchive/Products/Applications/
+        run: ls -la "$GITHUB_WORKSPACE/build/MASTestApp.xcarchive/Products/Applications/
 
       - name: Install Appium and Python Dependencies
         run: |

--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -60,6 +60,11 @@ jobs:
           name: Unsigned-iOS-App
           path: output/MASTestApp-unsigned.ipa
 
+
+      - name: Check Available Devices
+        run: |
+          xcrun simctl list devices available
+
       - name: Install Appium and Python Dependencies
         run: |
           npm install -g appium

--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -114,12 +114,31 @@ jobs:
             after_start.png
             final_screen.xml
 
-      - name: Generate Job Summary
+  summarize:
+    runs-on: ubuntu-latest
+    needs: build  # Wait until the build job completes
+    steps:
+      - name: Download UI Test Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: UI-Test-Artifacts
+          path: ./artifacts
+
+      - name: Create Job Summary
         run: |
-          BEFORE=$(base64 before_start.png | tr -d '\n')
-          AFTER=$(base64 after_start.png | tr -d '\n')
+          BEFORE=$(base64 ./artifacts/before_start.png | tr -d '\n')
+          AFTER=$(base64 ./artifacts/after_start.png | tr -d '\n')
+
           echo "## Job Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Test Artifacts:**" >> $GITHUB_STEP_SUMMARY
+          echo "### Test Artifacts" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "<table><tr><td><img src='data:image/png;base64,$BEFORE' width='300'></td><td><img src='data:image/png;base64,$AFTER' width='300'></td></tr></table>" >> $GITHUB_STEP_SUMMARY
+
+          # Display the two images side by side in a table
+          echo "<table><tr>" >> $GITHUB_STEP_SUMMARY
+          echo "<td><img src='data:image/png;base64,$BEFORE' width='300'></td>" >> $GITHUB_STEP_SUMMARY
+          echo "<td><img src='data:image/png;base64,$AFTER' width='300'></td>" >> $GITHUB_STEP_SUMMARY
+          echo "</tr></table>" >> $GITHUB_STEP_SUMMARY
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**XML Dump:** final_screen.xml (download from artifacts)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -126,8 +126,6 @@ jobs:
 
       - name: Create Job Summary
         run: |
-          BEFORE=$(base64 ./artifacts/before_start.png | tr -d '\n')
-          AFTER=$(base64 ./artifacts/after_start.png | tr -d '\n')
 
           echo "## Job Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -136,8 +134,8 @@ jobs:
 
           # Display the two images side by side in a table
           echo "<table><tr>" >> $GITHUB_STEP_SUMMARY
-          echo "<td><img src='data:image/png;base64,$BEFORE' width='300'></td>" >> $GITHUB_STEP_SUMMARY
-          echo "<td><img src='data:image/png;base64,$AFTER' width='300'></td>" >> $GITHUB_STEP_SUMMARY
+          echo "<td><img src='./artifacts/before_start.png' width='300'></td>" >> $GITHUB_STEP_SUMMARY
+          echo "<td><img src='./artifacts/after_start.png' width='300'></td>" >> $GITHUB_STEP_SUMMARY
           echo "</tr></table>" >> $GITHUB_STEP_SUMMARY
 
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ios-appium.yml
+++ b/.github/workflows/ios-appium.yml
@@ -61,7 +61,7 @@ jobs:
           path: output/MASTestApp-unsigned.ipa
 
       - name: List Applications Directory
-        run: ls -la "$GITHUB_WORKSPACE/build/MASTestApp.xcarchive/Products/Applications/"
+        run: ls -la "$GITHUB_WORKSPACE/build/MASTestApp.xcarchive/Products/Payload"
 
       - name: Install Appium and Python Dependencies
         run: |
@@ -81,7 +81,7 @@ jobs:
       - name: Run Appium UI Test
         env:
           # Pass the built app's path to the test script; Appium requires the .app folder.
-          APP_PATH: "build/MASTestApp.xcarchive/Products/Applications/MASTestApp.app"
+          APP_PATH: "build/MASTestApp.xcarchive/Products/Payload/MASTestApp.app"
         run: |
           python3 tools/appium_script.py
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build, Run and Capture Screenshot on iOS Simulator
     runs-on: macos-latest
     env:
-      BUNDLE_IDENTIFIER: com.example.MASTestApp  # <-- Update this with your actual bundle identifier
+      BUNDLE_IDENTIFIER: com.example.MASTestApp  # <-- Update with your actual bundle identifier
       PLATFORM: "iOS Simulator"
 
     steps:
@@ -21,16 +21,22 @@ jobs:
       - name: Set Default Scheme
         run: |
           scheme_list=$(xcodebuild -list -json | tr -d "\n")
-          default=$(echo $scheme_list | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
+          default=$(echo "$scheme_list" | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
           echo "$default" > default
           echo "Using default scheme: $default"
+
+      - name: Get Simulator UDID
+        id: get_simulator
+        run: |
+          # This finds the UDID of the first available iPhone simulator
+          UDID=$(xcrun simctl list devices available | grep -E "iPhone" | head -1 | awk -F '[()]' '{print $2}' | tr -d ' ')
+          echo "Simulator UDID: $UDID"
+          echo "UDID=$UDID" >> $GITHUB_OUTPUT
 
       - name: Build App
         env:
           scheme: ${{ 'default' }}
         run: |
-          # Select the first available iPhone device from xctrace output
-          device=$(xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//")
           if [ "$scheme" = "default" ]; then scheme=$(cat default); fi
           if ls -A | grep -iq "\.xcworkspace$"; then
             filetype_parameter="workspace"
@@ -39,29 +45,34 @@ jobs:
             filetype_parameter="project"
             file_to_build=$(ls -A | grep -i "\.xcodeproj$")
           fi
-          file_to_build=$(echo $file_to_build | awk '{$1=$1;print}')
-          xcodebuild build -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$PLATFORM,name=$device"
+          file_to_build=$(echo "$file_to_build" | awk '{$1=$1;print}')
+          xcodebuild build -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$PLATFORM,udid=${{ steps.get_simulator.outputs.UDID }}"
+
+      - name: Boot Simulator
+        run: |
+          # Boot the simulator (if not already booted)
+          xcrun simctl boot ${{ steps.get_simulator.outputs.UDID }} || echo "Simulator already booted"
+          # Give the simulator time to finish booting
+          sleep 10
 
       - name: Install and Launch App on Simulator
         run: |
-          # Wait for the simulator to be ready
-          sleep 5
-          # Attempt to locate the built .app file in DerivedData
+          # Locate the built .app file from DerivedData
           APP_PATH=$(find ~/Library/Developer/Xcode/DerivedData -name "*.app" | head -n 1)
           if [ -z "$APP_PATH" ]; then
             echo "Error: Could not find the built .app file."
             exit 1
           fi
           echo "Installing app from: $APP_PATH"
-          xcrun simctl install booted "$APP_PATH"
+          xcrun simctl install ${{ steps.get_simulator.outputs.UDID }} "$APP_PATH"
           echo "Launching app with bundle identifier $BUNDLE_IDENTIFIER"
-          xcrun simctl launch booted "$BUNDLE_IDENTIFIER"
+          xcrun simctl launch ${{ steps.get_simulator.outputs.UDID }} "$BUNDLE_IDENTIFIER"
 
       - name: Capture Screenshot
         run: |
-          # Wait for the app to fully launch (adjust delay as needed)
+          # Wait to ensure the app has fully launched
           sleep 10
-          xcrun simctl io booted screenshot screenshot.png
+          xcrun simctl io ${{ steps.get_simulator.outputs.UDID }} screenshot screenshot.png
 
       - name: Upload Screenshot Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       BUNDLE_IDENTIFIER: org.owasp.mastestapp.MASTestApp-iOS  # Update with your actual bundle identifier
       PLATFORM: "iOS Simulator"
+      SIMULATOR: "iPhone 16"
 
     steps:
       - name: Checkout Code
@@ -33,18 +34,6 @@ jobs:
           echo "DEFAULT_SCHEME=$default" >> $GITHUB_ENV
           echo "Using default scheme: $default"
 
-      - name: Get Simulator UDID
-        id: get_simulator
-        run: |
-          # Retrieve UDID for iPhone 15 with OS:17.2 from simctl list output
-          UDID=$(xcrun simctl list devices available | grep -E "iPhone 15" | grep "OS:17.2" | sed -nE 's/.*id:([A-F0-9-]+).*/\1/p' | head -n 1)
-          if [ -z "$UDID" ]; then
-            echo "Error: No iPhone 15 with OS:17.2 found."
-            exit 1
-          fi
-          echo "Simulator UDID: $UDID"
-          echo "UDID=$UDID" >> $GITHUB_OUTPUT
-
       - name: Build App for Simulator
         run: |
           if ls -A | grep -iq "\.xcworkspace$"; then
@@ -59,13 +48,13 @@ jobs:
           xcodebuild build \
             -scheme "$DEFAULT_SCHEME" \
             -"$filetype_parameter" "$file_to_build" \
-            -destination "platform=$PLATFORM,udid=${{ steps.get_simulator.outputs.UDID }}" \
+            -destination "platform=$PLATFORM,name=$SIMULATOR" \
             CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
 
       - name: Boot Simulator
         run: |
           # Boot the selected simulator if not already booted
-          xcrun simctl boot ${{ steps.get_simulator.outputs.UDID }} || echo "Simulator already booted"
+          xcrun simctl boot "$SIMULATOR" || echo "Simulator already booted"
           # Allow time for the simulator to finish booting
           sleep 10
 
@@ -78,15 +67,15 @@ jobs:
             exit 1
           fi
           echo "Installing app from: $APP_PATH"
-          xcrun simctl install ${{ steps.get_simulator.outputs.UDID }} "$APP_PATH"
+          xcrun simctl install "$SIMULATOR" "$APP_PATH"
           echo "Launching app with bundle identifier $BUNDLE_IDENTIFIER"
-          xcrun simctl launch ${{ steps.get_simulator.outputs.UDID }} "$BUNDLE_IDENTIFIER"
+          xcrun simctl launch "$SIMULATOR" "$BUNDLE_IDENTIFIER"
 
       - name: Capture Screenshot
         run: |
           # Wait for the app to fully launch before taking a screenshot
           sleep 10
-          xcrun simctl io ${{ steps.get_simulator.outputs.UDID }} screenshot screenshot.png
+          xcrun simctl io "$SIMULATOR" screenshot screenshot.png
 
       - name: Upload Screenshot Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -65,7 +65,7 @@ jobs:
           xcrun simctl io booted screenshot screenshot.png
 
       - name: Upload Screenshot Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: iOS-Screenshot
           path: screenshot.png

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,115 +1,33 @@
-name: Xcode - Build, Run & Screenshot (Simulator Build, Unsigned)
+name: Xcode - Buid
 
 on:
   push:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-  workflow_dispatch:
 
 jobs:
   build:
+    name: Build and Test default scheme using any available iPhone simulator
     runs-on: macos-latest
-    env:
-      BUNDLE_IDENTIFIER: org.owasp.mastestapp.MASTestApp-iOS  # Update with your actual bundle identifier
-      PLATFORM: "iOS Simulator"
-      SIMULATOR: "iPhone 16"
 
     steps:
-      - name: Checkout Code
+      - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Install Appium and Python Dependencies
-        run: |
-          npm install -g appium
-          python3 -m pip install --break-system-packages Appium-Python-Client
-      
-      - name: Install Appium Driver for XCUITest
-        run: |
-          appium driver install xcuitest
-
-      - name: Start Appium Server
-        run: |
-          # Start Appium in the background and give it a few seconds to initialize
-          appium & 
-          # sleep 10
-
-      - name: Install Dependencies
-        run: |
-          brew install ldid || true
-          brew install cocoapods || true
-          if [ -f Podfile ]; then
-            pod install --repo-update || true
-          fi
-
       - name: Set Default Scheme
         run: |
           scheme_list=$(xcodebuild -list -json | tr -d "\n")
-          default=$(echo "$scheme_list" | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
-          echo "DEFAULT_SCHEME=$default" >> $GITHUB_ENV
-          echo "Using default scheme: $default"
-
-      - name: Build App for Simulator
-        run: |
-          if ls -A | grep -iq "\.xcworkspace$"; then
-            filetype_parameter="workspace"
-            file_to_build=$(ls -A | grep -i "\.xcworkspace$")
-          else
-            filetype_parameter="project"
-            file_to_build=$(ls -A | grep -i "\.xcodeproj$")
-          fi
-          file_to_build=$(echo "$file_to_build" | awk '{$1=$1;print}')
-          # Build for simulator with code signing disabled
-          xcodebuild build \
-            -scheme "$DEFAULT_SCHEME" \
-            -"$filetype_parameter" "$file_to_build" \
-            -destination "platform=$PLATFORM,name=$SIMULATOR" \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
-
-      - name: Boot Simulator
-        run: |
-          # Boot the selected simulator if not already booted
-          xcrun simctl boot "$SIMULATOR" || echo "Simulator already booted"
-          # Allow time for the simulator to finish booting
-          sleep 10
-
-      - name: Install and Launch App on Simulator
-        run: |
-          # Locate the built .app from DerivedData
-          APP_PATH=$(find ~/Library/Developer/Xcode/DerivedData -name "*.app" | head -n 1)
-          if [ -z "$APP_PATH" ]; then
-            echo "Error: Could not find the built .app file."
-            exit 1
-          fi
-          echo "Installing app from: $APP_PATH"
-          xcrun simctl install "$SIMULATOR" "$APP_PATH"
-          echo "Launching app with bundle identifier $BUNDLE_IDENTIFIER"
-          xcrun simctl launch "$SIMULATOR" "$BUNDLE_IDENTIFIER"
-
-      - name: Capture Screenshot
-        run: |
-          # Wait for the app to fully launch before taking a screenshot
-          sleep 10
-          xcrun simctl io "$SIMULATOR" screenshot screenshot.png
-
-      - name: Upload Screenshot Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: iOS-Screenshot
-          path: screenshot.png
-
-      - name: Run Appium UI Test
+          default=$(echo $scheme_list | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
+          echo $default | cat >default
+          echo Using default scheme: $default
+      - name: Build
         env:
-          # Pass the built app's path to the test script; Appium requires the .app folder.
-          APP_PATH: "build/MASTestApp.xcarchive/Products/Applications/MASTestApp.app"
+          scheme: ${{ 'default' }}
+          platform: ${{ 'iOS Simulator' }}
         run: |
-          python3 tools/appium_script.py
-
-      - name: Upload Test Artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: UI-Test-Artifacts
-          path: |
-            before_start.png
-            after_start.png
-            final_screen.xml
+          # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
+          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
+          if [ $scheme = default ]; then scheme=$(cat default); fi
+          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
+          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
+          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=$device"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -3,15 +3,13 @@ name: Xcode - Build, Run & Screenshot (Simulator Build, Unsigned)
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: macos-latest
     env:
-      BUNDLE_IDENTIFIER: org.owasp.mastestapp.MASTestApp-iOS
+      BUNDLE_IDENTIFIER: org.owasp.mastestapp.MASTestApp-iOS  # Update with your actual bundle identifier
       PLATFORM: "iOS Simulator"
 
     steps:
@@ -36,8 +34,16 @@ jobs:
       - name: Get Simulator UDID
         id: get_simulator
         run: |
-          # Find the UDID of the first available iPhone simulator
-          UDID=$(xcrun simctl list devices available | grep -E "iPhone" | head -1 | awk -F '[()]' '{print $2}' | tr -d ' ')
+          # Try to select an iPhone 15 with OS 17.2
+          UDID=$(xcrun simctl list devices available | grep "iPhone 15" | grep "OS 17.2" | head -1 | awk -F '[()]' '{print $2}' | tr -d ' ')
+          if [ -z "$UDID" ]; then
+            echo "No iPhone 15 with OS 17.2 found. Trying any iPhone with OS version 17.2 or higher."
+            UDID=$(xcrun simctl list devices available | grep -E "iPhone" | grep "OS 17\.[2-9]" | head -1 | awk -F '[()]' '{print $2}' | tr -d ' ')
+          fi
+          if [ -z "$UDID" ]; then
+            echo "Error: No suitable simulator with OS 17.2 or higher found."
+            exit 1
+          fi
           echo "Simulator UDID: $UDID"
           echo "UDID=$UDID" >> $GITHUB_OUTPUT
 
@@ -60,7 +66,7 @@ jobs:
 
       - name: Boot Simulator
         run: |
-          # Boot the simulator using its UDID (if not already booted)
+          # Boot the selected simulator if not already booted
           xcrun simctl boot ${{ steps.get_simulator.outputs.UDID }} || echo "Simulator already booted"
           # Allow time for the simulator to finish booting
           sleep 10

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -3,6 +3,8 @@ name: Xcode - Build, Run & Screenshot (Simulator Build, Unsigned)
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Run Appium UI Test
         env:
           # Pass the built app's path to the test script; Appium requires the .app folder.
-          APP_PATH: "build/MASTestApp.xcarchive/Products/Payload/MASTestApp.app"
+          APP_PATH: "build/MASTestApp.xcarchive/Products/Applications/MASTestApp.app"
         run: |
           python3 tools/appium_script.py
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -3,8 +3,6 @@ name: Xcode - Build, Run & Screenshot (Simulator Build, Unsigned)
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:
@@ -36,14 +34,10 @@ jobs:
       - name: Get Simulator UDID
         id: get_simulator
         run: |
-          # Try to select an iPhone 15 with OS 17.2
-          UDID=$(xcrun simctl list devices available | grep "iPhone 15" | grep "OS 17.2" | head -1 | awk -F '[()]' '{print $2}' | tr -d ' ')
+          # Retrieve UDID for iPhone 15 with OS:17.2 from simctl list output
+          UDID=$(xcrun simctl list devices available | grep -E "iPhone 15" | grep "OS:17.2" | sed -nE 's/.*id:([A-F0-9-]+).*/\1/p' | head -n 1)
           if [ -z "$UDID" ]; then
-            echo "No iPhone 15 with OS 17.2 found. Trying any iPhone with OS version 17.2 or higher."
-            UDID=$(xcrun simctl list devices available | grep -E "iPhone" | grep "OS 17\.[2-9]" | head -1 | awk -F '[()]' '{print $2}' | tr -d ' ')
-          fi
-          if [ -z "$UDID" ]; then
-            echo "Error: No suitable simulator with OS 17.2 or higher found."
+            echo "Error: No iPhone 15 with OS:17.2 found."
             exit 1
           fi
           echo "Simulator UDID: $UDID"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,4 +1,4 @@
-name: Xcode - Build, Test & Screenshot
+name: Xcode - Build, Run & Screenshot
 
 on:
   push:
@@ -8,8 +8,11 @@ on:
 
 jobs:
   build:
-    name: Build, Test and Capture Screenshot on iOS Simulator
+    name: Build, Run and Capture Screenshot on iOS Simulator
     runs-on: macos-latest
+    env:
+      BUNDLE_IDENTIFIER: com.example.MASTestApp  # <-- Update this with your actual bundle identifier
+      PLATFORM: "iOS Simulator"
 
     steps:
       - name: Checkout
@@ -22,10 +25,9 @@ jobs:
           echo "$default" > default
           echo "Using default scheme: $default"
 
-      - name: Build for Testing
+      - name: Build App
         env:
           scheme: ${{ 'default' }}
-          platform: ${{ 'iOS Simulator' }}
         run: |
           # Select the first available iPhone device from xctrace output
           device=$(xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//")
@@ -38,30 +40,27 @@ jobs:
             file_to_build=$(ls -A | grep -i "\.xcodeproj$")
           fi
           file_to_build=$(echo $file_to_build | awk '{$1=$1;print}')
-          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=$device"
+          xcodebuild build -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$PLATFORM,name=$device"
 
-      - name: Run Tests
-        env:
-          scheme: ${{ 'default' }}
-          platform: ${{ 'iOS Simulator' }}
+      - name: Install and Launch App on Simulator
         run: |
-          # Get the device name as above
-          device=$(xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//")
-          if [ "$scheme" = "default" ]; then scheme=$(cat default); fi
-          if ls -A | grep -iq "\.xcworkspace$"; then
-            filetype_parameter="workspace"
-            file_to_build=$(ls -A | grep -i "\.xcworkspace$")
-          else
-            filetype_parameter="project"
-            file_to_build=$(ls -A | grep -i "\.xcodeproj$")
+          # Wait for the simulator to be ready
+          sleep 5
+          # Attempt to locate the built .app file in DerivedData
+          APP_PATH=$(find ~/Library/Developer/Xcode/DerivedData -name "*.app" | head -n 1)
+          if [ -z "$APP_PATH" ]; then
+            echo "Error: Could not find the built .app file."
+            exit 1
           fi
-          file_to_build=$(echo $file_to_build | awk '{$1=$1;print}')
-          xcodebuild test -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=$device"
+          echo "Installing app from: $APP_PATH"
+          xcrun simctl install booted "$APP_PATH"
+          echo "Launching app with bundle identifier $BUNDLE_IDENTIFIER"
+          xcrun simctl launch booted "$BUNDLE_IDENTIFIER"
 
       - name: Capture Screenshot
         run: |
-          # Allow time for the app to fully launch; adjust if needed.
-          sleep 5
+          # Wait for the app to fully launch (adjust delay as needed)
+          sleep 10
           xcrun simctl io booted screenshot screenshot.png
 
       - name: Upload Screenshot Artifact

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,43 +1,46 @@
-name: Xcode - Build, Run & Screenshot
+name: Xcode - Build, Run & Screenshot (Simulator Build, Unsigned)
 
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
   build:
-    name: Build, Run and Capture Screenshot on iOS Simulator
     runs-on: macos-latest
     env:
-      BUNDLE_IDENTIFIER: com.example.MASTestApp  # <-- Update with your actual bundle identifier
+      BUNDLE_IDENTIFIER: org.owasp.mastestapp.MASTestApp-iOS
       PLATFORM: "iOS Simulator"
 
     steps:
-      - name: Checkout
+      - name: Checkout Code
         uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: |
+          brew install ldid || true
+          brew install cocoapods || true
+          if [ -f Podfile ]; then
+            pod install --repo-update || true
+          fi
 
       - name: Set Default Scheme
         run: |
           scheme_list=$(xcodebuild -list -json | tr -d "\n")
           default=$(echo "$scheme_list" | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
-          echo "$default" > default
+          echo "DEFAULT_SCHEME=$default" >> $GITHUB_ENV
           echo "Using default scheme: $default"
 
       - name: Get Simulator UDID
         id: get_simulator
         run: |
-          # This finds the UDID of the first available iPhone simulator
+          # Find the UDID of the first available iPhone simulator
           UDID=$(xcrun simctl list devices available | grep -E "iPhone" | head -1 | awk -F '[()]' '{print $2}' | tr -d ' ')
           echo "Simulator UDID: $UDID"
           echo "UDID=$UDID" >> $GITHUB_OUTPUT
 
-      - name: Build App
-        env:
-          scheme: ${{ 'default' }}
+      - name: Build App for Simulator
         run: |
-          if [ "$scheme" = "default" ]; then scheme=$(cat default); fi
           if ls -A | grep -iq "\.xcworkspace$"; then
             filetype_parameter="workspace"
             file_to_build=$(ls -A | grep -i "\.xcworkspace$")
@@ -46,18 +49,23 @@ jobs:
             file_to_build=$(ls -A | grep -i "\.xcodeproj$")
           fi
           file_to_build=$(echo "$file_to_build" | awk '{$1=$1;print}')
-          xcodebuild build -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$PLATFORM,udid=${{ steps.get_simulator.outputs.UDID }}"
+          # Build for simulator with code signing disabled
+          xcodebuild build \
+            -scheme "$DEFAULT_SCHEME" \
+            -"$filetype_parameter" "$file_to_build" \
+            -destination "platform=$PLATFORM,udid=${{ steps.get_simulator.outputs.UDID }}" \
+            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
 
       - name: Boot Simulator
         run: |
-          # Boot the simulator (if not already booted)
+          # Boot the simulator using its UDID (if not already booted)
           xcrun simctl boot ${{ steps.get_simulator.outputs.UDID }} || echo "Simulator already booted"
-          # Give the simulator time to finish booting
+          # Allow time for the simulator to finish booting
           sleep 10
 
       - name: Install and Launch App on Simulator
         run: |
-          # Locate the built .app file from DerivedData
+          # Locate the built .app from DerivedData
           APP_PATH=$(find ~/Library/Developer/Xcode/DerivedData -name "*.app" | head -n 1)
           if [ -z "$APP_PATH" ]; then
             echo "Error: Could not find the built .app file."
@@ -70,7 +78,7 @@ jobs:
 
       - name: Capture Screenshot
         run: |
-          # Wait to ensure the app has fully launched
+          # Wait for the app to fully launch before taking a screenshot
           sleep 10
           xcrun simctl io ${{ steps.get_simulator.outputs.UDID }} screenshot screenshot.png
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -19,6 +19,21 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Install Appium and Python Dependencies
+        run: |
+          npm install -g appium
+          python3 -m pip install --break-system-packages Appium-Python-Client
+      
+      - name: Install Appium Driver for XCUITest
+        run: |
+          appium driver install xcuitest
+
+      - name: Start Appium Server
+        run: |
+          # Start Appium in the background and give it a few seconds to initialize
+          appium & 
+          # sleep 10
+
       - name: Install Dependencies
         run: |
           brew install ldid || true
@@ -82,3 +97,19 @@ jobs:
         with:
           name: iOS-Screenshot
           path: screenshot.png
+
+      - name: Run Appium UI Test
+        env:
+          # Pass the built app's path to the test script; Appium requires the .app folder.
+          APP_PATH: "build/MASTestApp.xcarchive/Products/Payload/MASTestApp.app"
+        run: |
+          python3 tools/appium_script.py
+
+      - name: Upload Test Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: UI-Test-Artifacts
+          path: |
+            before_start.png
+            after_start.png
+            final_screen.xml

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,4 +1,4 @@
-name: Xcode - Buid
+name: Xcode - Build, Test & Screenshot
 
 on:
   push:
@@ -8,26 +8,64 @@ on:
 
 jobs:
   build:
-    name: Build and Test default scheme using any available iPhone simulator
+    name: Build, Test and Capture Screenshot on iOS Simulator
     runs-on: macos-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Set Default Scheme
         run: |
           scheme_list=$(xcodebuild -list -json | tr -d "\n")
           default=$(echo $scheme_list | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
-          echo $default | cat >default
-          echo Using default scheme: $default
-      - name: Build
+          echo "$default" > default
+          echo "Using default scheme: $default"
+
+      - name: Build for Testing
         env:
           scheme: ${{ 'default' }}
           platform: ${{ 'iOS Simulator' }}
         run: |
-          # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
-          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
-          if [ $scheme = default ]; then scheme=$(cat default); fi
-          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
-          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
+          # Select the first available iPhone device from xctrace output
+          device=$(xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//")
+          if [ "$scheme" = "default" ]; then scheme=$(cat default); fi
+          if ls -A | grep -iq "\.xcworkspace$"; then
+            filetype_parameter="workspace"
+            file_to_build=$(ls -A | grep -i "\.xcworkspace$")
+          else
+            filetype_parameter="project"
+            file_to_build=$(ls -A | grep -i "\.xcodeproj$")
+          fi
+          file_to_build=$(echo $file_to_build | awk '{$1=$1;print}')
           xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=$device"
+
+      - name: Run Tests
+        env:
+          scheme: ${{ 'default' }}
+          platform: ${{ 'iOS Simulator' }}
+        run: |
+          # Get the device name as above
+          device=$(xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//")
+          if [ "$scheme" = "default" ]; then scheme=$(cat default); fi
+          if ls -A | grep -iq "\.xcworkspace$"; then
+            filetype_parameter="workspace"
+            file_to_build=$(ls -A | grep -i "\.xcworkspace$")
+          else
+            filetype_parameter="project"
+            file_to_build=$(ls -A | grep -i "\.xcodeproj$")
+          fi
+          file_to_build=$(echo $file_to_build | awk '{$1=$1;print}')
+          xcodebuild test -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=$device"
+
+      - name: Capture Screenshot
+        run: |
+          # Allow time for the app to fully launch; adjust if needed.
+          sleep 5
+          xcrun simctl io booted screenshot screenshot.png
+
+      - name: Upload Screenshot Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: iOS-Screenshot
+          path: screenshot.png

--- a/tools/appium_script.py
+++ b/tools/appium_script.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 This script uses Appium's Python client to:
-- Connect to an Appium server and start a session for an iOS app.
+- Connect to an Appium server and attach to a running iOS app.
 - Capture a screenshot before clicking a button labeled "Start".
 - Click the "Start" button.
 - Capture another screenshot after clicking.
@@ -12,30 +12,32 @@ This script uses Appium's Python client to:
 
 from appium import webdriver
 from appium.options.ios import XCUITestOptions
-import os
 import time
 from appium.webdriver.common.appiumby import AppiumBy
 
 def main():
     # Get the built app path from the environment variable.
-    # app_path = os.getenv('APP_PATH')    
-    # Set up options using the new API
+    # app_path = os.getenv('APP_PATH')
+    # options.app = app_path
+
+    # Set up options
     options = XCUITestOptions()
     options.platform_version = "18.1"
     options.device_name = "iPhone 16"
-    # options.app = app_path
+    
     # Use the bundle identifier to attach to the running app
     options.bundle_id = "org.owasp.mastestapp.MASTestApp-iOS"
     # Prevent Appium from automatically launching the app
     options.auto_launch = False
+    # Prevent Appium from resetting the app state (maybe remove)
     options.no_reset = True
 
     # Connect to Appium using the options parameter
     driver = webdriver.Remote("http://localhost:4723", options=options)
-    driver.implicitly_wait(10)
+    driver.implicitly_wait(3)
 
     # Wait for the app to load.
-    time.sleep(5)
+    # time.sleep(5)
 
     # Capture a screenshot before clicking the "Start" button.
     driver.save_screenshot("before_start.png")

--- a/tools/appium_script.py
+++ b/tools/appium_script.py
@@ -34,7 +34,7 @@ def main():
 
     # Connect to Appium using the options parameter
     driver = webdriver.Remote("http://localhost:4723", options=options)
-    driver.implicitly_wait(3)
+    driver.implicitly_wait(3) # or 10
 
     # Wait for the app to load.
     # time.sleep(5)

--- a/tools/appium_script.py
+++ b/tools/appium_script.py
@@ -22,8 +22,8 @@ def main():
     
     # Set up options using the new API
     options = XCUITestOptions()
-    options.platform_version = "17.4"        # Your IPHONEOS_DEPLOYMENT_TARGET
-    options.device_name = "iPhone Simulator"   # Adjust if needed (e.g., "iPhone 14")
+    options.platform_version = "17.4"
+    options.device_name = "iPhone 15"
     options.app = app_path
     options.no_reset = True
 

--- a/tools/appium_script.py
+++ b/tools/appium_script.py
@@ -9,40 +9,36 @@ This script uses Appium's Python client to:
 - Save the screenshots and XML file for further inspection.
 """
 
-import time
+
 from appium import webdriver
+from appium.options.ios import XCUITestOptions
+import os
+import time
 from appium.webdriver.common.appiumby import AppiumBy
 
-import os
-
 def main():
-
+    # Get the built app path from the environment variable.
     app_path = os.getenv('APP_PATH', '$GITHUB_WORKSPACE/build/MASTestApp.xcarchive/Products/Applications/MASTestApp.app')
+    
+    # Set up options using the new API
+    options = XCUITestOptions()
+    options.platform_version = "17.4"        # Your IPHONEOS_DEPLOYMENT_TARGET
+    options.device_name = "iPhone Simulator"   # Adjust if needed (e.g., "iPhone 14")
+    options.app = app_path
+    options.no_reset = True
 
-    desired_caps = {
-        "platformName": "iOS",
-        "platformVersion": "17.4",  # Matches your IPHONEOS_DEPLOYMENT_TARGET
-        "deviceName": "iPhone Simulator",  # Adjust if necessary (e.g., "iPhone 14")
-        "automationName": "XCUITest",
-        "app": app_path,  # Use the built app's path from the GitHub Actions environment
-        "noReset": True
-        # Optionally, you could add the bundle ID if attaching to an already-installed app:
-        # "bundleId": "org.owasp.mastestapp.MASTestApp-iOS",
-    }
-
-
-    # Connect to the Appium server (make sure it is running).
-    driver = webdriver.Remote("http://localhost:4723/wd/hub", desired_caps)
+    # Connect to Appium using the options parameter
+    driver = webdriver.Remote("http://localhost:4723/wd/hub", options=options)
     driver.implicitly_wait(10)
 
-    # Allow the app to fully load.
+    # Wait for the app to load.
     time.sleep(5)
 
     # Capture a screenshot before clicking the "Start" button.
     driver.save_screenshot("before_start.png")
     print("Saved screenshot: before_start.png")
 
-    # Locate and click the "Start" button using its accessibility ID.
+    # Locate and click the "Start" button.
     try:
         start_button = driver.find_element(AppiumBy.ACCESSIBILITY_ID, "Start")
         start_button.click()
@@ -52,7 +48,7 @@ def main():
         driver.quit()
         return
 
-    # Wait for any UI transition after the click.
+    # Wait for any UI transitions after the click.
     time.sleep(3)
 
     # Capture a screenshot after clicking the "Start" button.
@@ -63,7 +59,7 @@ def main():
     xml_dump = driver.page_source
     with open("final_screen.xml", "w", encoding="utf-8") as f:
         f.write(xml_dump)
-    print("Saved final UI dump to: final_screen.xml")
+    print("Saved final UI dump to final_screen.xml")
 
     # End the Appium session.
     driver.quit()

--- a/tools/appium_script.py
+++ b/tools/appium_script.py
@@ -34,10 +34,10 @@ def main():
 
     # Connect to Appium using the options parameter
     driver = webdriver.Remote("http://localhost:4723", options=options)
-    driver.implicitly_wait(3) # or 10
+    driver.implicitly_wait(10)
 
     # Wait for the app to load.
-    # time.sleep(5)
+    time.sleep(5)
 
     # Capture a screenshot before clicking the "Start" button.
     driver.save_screenshot("before_start.png")

--- a/tools/appium_script.py
+++ b/tools/appium_script.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""
+This script uses Appium's Python client to:
+- Connect to an Appium server and start a session for an iOS app.
+- Capture a screenshot before clicking a button labeled "Start".
+- Click the "Start" button.
+- Capture another screenshot after clicking.
+- Dump the final UI hierarchy as XML.
+- Save the screenshots and XML file for further inspection.
+"""
+
+import time
+from appium import webdriver
+from appium.webdriver.common.appiumby import AppiumBy
+
+import os
+
+def main():
+
+    app_path = os.getenv('APP_PATH', '$GITHUB_WORKSPACE/build/MASTestApp.xcarchive/Products/Applications/MASTestApp.app')
+
+    desired_caps = {
+        "platformName": "iOS",
+        "platformVersion": "17.4",  # Matches your IPHONEOS_DEPLOYMENT_TARGET
+        "deviceName": "iPhone Simulator",  # Adjust if necessary (e.g., "iPhone 14")
+        "automationName": "XCUITest",
+        "app": app_path,  # Use the built app's path from the GitHub Actions environment
+        "noReset": True
+        # Optionally, you could add the bundle ID if attaching to an already-installed app:
+        # "bundleId": "org.owasp.mastestapp.MASTestApp-iOS",
+    }
+
+
+    # Connect to the Appium server (make sure it is running).
+    driver = webdriver.Remote("http://localhost:4723/wd/hub", desired_caps)
+    driver.implicitly_wait(10)
+
+    # Allow the app to fully load.
+    time.sleep(5)
+
+    # Capture a screenshot before clicking the "Start" button.
+    driver.save_screenshot("before_start.png")
+    print("Saved screenshot: before_start.png")
+
+    # Locate and click the "Start" button using its accessibility ID.
+    try:
+        start_button = driver.find_element(AppiumBy.ACCESSIBILITY_ID, "Start")
+        start_button.click()
+        print("Clicked the 'Start' button.")
+    except Exception as e:
+        print(f"Error: Unable to locate or click the 'Start' button. Details: {e}")
+        driver.quit()
+        return
+
+    # Wait for any UI transition after the click.
+    time.sleep(3)
+
+    # Capture a screenshot after clicking the "Start" button.
+    driver.save_screenshot("after_start.png")
+    print("Saved screenshot: after_start.png")
+
+    # Dump the final UI hierarchy as XML.
+    xml_dump = driver.page_source
+    with open("final_screen.xml", "w", encoding="utf-8") as f:
+        f.write(xml_dump)
+    print("Saved final UI dump to: final_screen.xml")
+
+    # End the Appium session.
+    driver.quit()
+
+if __name__ == '__main__':
+    main()

--- a/tools/appium_script.py
+++ b/tools/appium_script.py
@@ -18,8 +18,7 @@ from appium.webdriver.common.appiumby import AppiumBy
 
 def main():
     # Get the built app path from the environment variable.
-    app_path = os.getenv('APP_PATH', '$GITHUB_WORKSPACE/build/MASTestApp.xcarchive/Products/Applications/MASTestApp.app')
-    
+    app_path = os.getenv('APP_PATH')    
     # Set up options using the new API
     options = XCUITestOptions()
     options.platform_version = "17.4"

--- a/tools/appium_script.py
+++ b/tools/appium_script.py
@@ -21,8 +21,8 @@ def main():
     app_path = os.getenv('APP_PATH')    
     # Set up options using the new API
     options = XCUITestOptions()
-    options.platform_version = "17.4"
-    options.device_name = "iPhone 15"
+    options.platform_version = "18.1"
+    options.device_name = "iPhone 16"
     options.app = app_path
     options.no_reset = True
 

--- a/tools/appium_script.py
+++ b/tools/appium_script.py
@@ -28,7 +28,7 @@ def main():
     options.no_reset = True
 
     # Connect to Appium using the options parameter
-    driver = webdriver.Remote("http://localhost:4723/wd/hub", options=options)
+    driver = webdriver.Remote("http://localhost:4723", options=options)
     driver.implicitly_wait(10)
 
     # Wait for the app to load.

--- a/tools/appium_script.py
+++ b/tools/appium_script.py
@@ -18,12 +18,16 @@ from appium.webdriver.common.appiumby import AppiumBy
 
 def main():
     # Get the built app path from the environment variable.
-    app_path = os.getenv('APP_PATH')    
+    # app_path = os.getenv('APP_PATH')    
     # Set up options using the new API
     options = XCUITestOptions()
     options.platform_version = "18.1"
     options.device_name = "iPhone 16"
-    options.app = app_path
+    # options.app = app_path
+    # Use the bundle identifier to attach to the running app
+    options.bundle_id = "org.owasp.mastestapp.MASTestApp-iOS"
+    # Prevent Appium from automatically launching the app
+    options.auto_launch = False
     options.no_reset = True
 
     # Connect to Appium using the options parameter


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to build the iOS app and run Appium tests. It includes:


### .github/workflows/ios-appium.yml

GitHub Actions workflow configuration file to automate testing with Appium on iOS Simulator.

- Checking out the code
- Installing Appium and its dependencies
- Building the iOS app for the simulator
- Booting the simulator and installing the app
- Capturing a screenshot of the app
- Running an Appium UI test and uploading artifacts

### tools/appium_script.py

A Python script that uses the Appium Python client to:

- Connect to an Appium server and attach to a running iOS app
- Capture screenshots before and after clicking a "Start" button
- Dump the final UI hierarchy as an XML file